### PR TITLE
Extend warning message about no IE support

### DIFF
--- a/src/template/_body.html
+++ b/src/template/_body.html
@@ -3,7 +3,7 @@
         var isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
         var isFirefox = /Firefox/.test(navigator.userAgent);
         if (!isChrome && !isFirefox) {
-            alert('This application was designed to be used in Google Chrome and Mozilla Firefox. Running the application in other browsers might result in performance issues or other misbehavior.');
+            alert('This application was designed to be used in Google Chrome and Mozilla Firefox and does not work in Internet Explorer. Running the application in other browsers might result in performance issues or other misbehavior.');
         }
     })();
 </script>


### PR DESCRIPTION
Closes #62

In IE 11 the following message is shown:

![grafik](https://user-images.githubusercontent.com/5851088/63697333-02e9e300-c81d-11e9-9553-f83cf81f89d1.png)

