### PR TITLE
Fix black Caleydo logo animation in production builds

### DIFF
--- a/src/assets/caleydo_c_anim.svg
+++ b/src/assets/caleydo_c_anim.svg
@@ -10,31 +10,16 @@
             opacity: 1; }
           100% {
             opacity: 0.2; } }
-        polygon {
+        svg .ani {
           animation-name: caleydo_opacity;
           animation-duration: 600ms;
           animation-direction: alternate;
           animation-iteration-count: infinite; }
-        svg polygon:nth-child(2) {
-            fill: #10ACDF;
-            animation-delay: 0ms; }
-        svg polygon:nth-child(3) {
-            fill: #1BA64E;
-            animation-delay: 100ms; }
-        svg polygon:nth-child(4) {
-            fill: #FABC15;
-            animation-delay: 200ms; }
-        svg polygon:nth-child(5) {
-            fill: #F47D20;
-            animation-delay: 300ms; }
-        svg polygon:nth-child(6) {
-            fill: #EE2329;
-            animation-delay: 400ms; }
   ]]>
   </style>
-<polygon points="63.166,138.946 120.33,105.942 63.166,72.937" />
-<polygon points="59.164,72.937 2,105.942 59.164,138.944" />
-<polygon points="57.164,69.472 0,36.468 0,102.478" />
-<polygon points="59.164,0 2,33.003 59.164,66.007" />
-<polygon points="63.166,66.008 120.33,33.004 63.166,0" />
+  <polygon class="ani" style="animation-delay:0ms" fill="#10acdf" points="63.166,138.946 120.33,105.942 63.166,72.937" />
+  <polygon class="ani" style="animation-delay:100ms" fill="#1ba64e" points="59.164,72.937 2,105.942 59.164,138.944" />
+  <polygon class="ani" style="animation-delay:200ms" fill="#fabc15" points="57.164,69.472 0,36.468 0,102.478" />
+  <polygon class="ani" style="animation-delay:300ms" fill="#f47d20" points="59.164,0 2,33.003 59.164,66.007" />
+  <polygon class="ani" style="animation-delay:400ms" fill="#ee2329" points="63.166,66.008 120.33,33.004 63.166,0" />
 </svg>


### PR DESCRIPTION
Closes #127

### Summary

* In production builds the `svgo` package removes unreferenced styles
   * svgo is part of [cssnano](https://cssnano.co/docs/optimisations/svgo) which is part of the [Webpack css-minimizer-plugin](https://github.com/webpack-contrib/css-minimizer-webpack-plugin)
   * The [css minimizer plugin was introduced with the StyleSheet refactoring](https://github.com/phovea/generator-phovea/pull/440) and is only applied in production builds (webpack.prod.js) -> hence, the effect is not visible in the developement build or when using webpack-dev-server
* The optimizer cannot handle the previously used `nth-child()` style and merged all pathes into a single path element
	* Finally, the style does not match any of the SVG elements
* Inlining the style as attributes and assigning a class solves the issue


Previously optimized SVG (formatted for readability)
```svg
<svg
	xmlns="http://www.w3.org/2000/svg" width="120.522" height="138.944">
	<style>
        @keyframes caleydo_opacity {
          0% {
            opacity: 1; }
          100% {
            opacity: 0.2; } }
        polygon {
          animation-name: caleydo_opacity;
          animation-duration: 600ms;
          animation-direction: alternate;
          animation-iteration-count: infinite; }
        svg polygon:nth-child(2) {
            fill: #10ACDF;
            animation-delay: 0ms; }
        svg polygon:nth-child(3) {
            fill: #1BA64E;
            animation-delay: 100ms; }
        svg polygon:nth-child(4) {
            fill: #FABC15;
            animation-delay: 200ms; }
        svg polygon:nth-child(5) {
            fill: #F47D20;
            animation-delay: 300ms; }
        svg polygon:nth-child(6) {
            fill: #EE2329;
            animation-delay: 400ms; }
	</style>
	<path d="M63.166 138.946l57.164-33.004-57.164-33.005zM59.164 72.937L2 105.942l57.164 33.002zM57.164 69.472L0 36.468v66.01zM59.164 0L2 33.003l57.164 33.004zM63.166 66.008l57.164-33.004L63.166 0z"/>
</svg>
```

Optimized SVG with this PR (formatted for readability)

```svg
<svg
	xmlns="http://www.w3.org/2000/svg" width="120.522" height="138.944">
	<style>
        @keyframes caleydo_opacity {
          0% {
            opacity: 1; }
          100% {
            opacity: 0.2; } }
        svg .ani{
          animation-name: caleydo_opacity;
          animation-duration: 600ms;
          animation-direction: alternate;
          animation-iteration-count: infinite; }
	</style>
	<path class="ani" style="animation-delay:0ms" fill="#10acdf" d="M63.166 138.946l57.164-33.004-57.164-33.005z"/>
	<path class="ani" style="animation-delay:100ms" fill="#1ba64e" d="M59.164 72.937L2 105.942l57.164 33.002z"/>
	<path class="ani" style="animation-delay:200ms" fill="#fabc15" d="M57.164 69.472L0 36.468v66.01z"/>
	<path class="ani" style="animation-delay:300ms" fill="#f47d20" d="M59.164 0L2 33.003l57.164 33.004z"/>
	<path class="ani" style="animation-delay:400ms" fill="#ee2329" d="M63.166 66.008l57.164-33.004L63.166 0z"/>
</svg>
```

